### PR TITLE
updating to lts-11.1

### DIFF
--- a/discord-hs.cabal
+++ b/discord-hs.cabal
@@ -40,7 +40,7 @@ library
                      , Network.Discord.Rest.HTTP
   -- other-extensions:
   build-depends:       base==4.*
-                     , aeson>=1.0 && <1.2
+                     , aeson>=1.0 && <1.3
                      , bytestring==0.10.*
                      , case-insensitive==1.2.*
                      , comonad==5.*
@@ -49,10 +49,10 @@ library
                      , hashable==1.2.*
                      , hslogger==1.2.*
                      , http-client==0.5.*
-                     , mmorph==1.0.*
+                     , mmorph==1.1.*
                      , mtl==2.2.*
                      , pipes==4.3.*
-                     , stm-conduit==3.0.*
+                     , stm-conduit==4.0.*
                      , stm==2.4.*
                      , text==1.2.*
                      , time>=1.6 && <1.9 
@@ -60,8 +60,8 @@ library
                      , unordered-containers==0.2.*
                      , url==2.1.*
                      , vector>=0.10 && <0.13
-                     , websockets==0.10.*
-                     , req==0.2.*
+                     , websockets==0.12.*
+                     , req==1.0.*
                      , wuss==1.1.*
   ghc-options:         -Wall
   hs-source-dirs:      src

--- a/src/Network/Discord/Rest/Prelude.hs
+++ b/src/Network/Discord/Rest/Prelude.hs
@@ -5,7 +5,6 @@
 module Network.Discord.Rest.Prelude where
   import Control.Concurrent (threadDelay)
 
-  import Control.Comonad
   import Control.Concurrent.STM
   import Data.Aeson
   import Data.Default

--- a/src/Network/Discord/Types/Gateway.hs
+++ b/src/Network/Discord/Types/Gateway.hs
@@ -118,3 +118,9 @@ module Network.Discord.Types.Gateway where
         Right payload -> payload
         Left  reason  -> ParseError reason
     toLazyByteString   = encode
+    fromDataMessage (Text bs _) = case eitherDecode bs of
+      Right payload -> payload
+      Left  reason  -> ParseError reason
+    fromDataMessage (Binary bs) = case eitherDecode bs of
+      Right payload -> payload
+      Left  reason  -> ParseError reason

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,11 @@
 extra-package-dbs: []
 packages:
 - '.'
-resolver: lts-8.5
+resolver: lts-11.1
 nix:
   shell-file: shell.nix
+
+extra-deps: [ url-2.1.3, hakyll-4.12.0.1 ]
+
+ghc-options:
+  "hakyll": -fexternal-interpreter


### PR DESCRIPTION
Using a more recent version to stackage lts, to make it easier to use with more recent versions of libraries.